### PR TITLE
replace "io/ioutil"

### DIFF
--- a/crypto/ecc/key.go
+++ b/crypto/ecc/key.go
@@ -13,14 +13,14 @@ import (
 	"crypto/rand"
 	"crypto/x509"
 	"encoding/pem"
+	"io"
+	"os"
+	"path"
+
 	"github.com/dobyte/due/v2/errors"
 	"github.com/dobyte/due/v2/utils/xconv"
 	"github.com/dobyte/due/v2/utils/xpath"
 	"github.com/ethereum/go-ethereum/crypto/ecies"
-	"io"
-	"io/ioutil"
-	"os"
-	"path"
 )
 
 type Key struct {
@@ -162,7 +162,7 @@ func loadKey(key string) (*pem.Block, error) {
 	)
 
 	if xpath.IsFile(key) {
-		buffer, err = ioutil.ReadFile(key)
+		buffer, err = os.ReadFile(key)
 		if err != nil {
 			return nil, err
 		}

--- a/crypto/rsa/key.go
+++ b/crypto/rsa/key.go
@@ -6,13 +6,13 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"encoding/pem"
+	"io"
+	"os"
+	"path"
+
 	"github.com/dobyte/due/v2/errors"
 	"github.com/dobyte/due/v2/utils/xconv"
 	"github.com/dobyte/due/v2/utils/xpath"
-	"io"
-	"io/ioutil"
-	"os"
-	"path"
 )
 
 type Format int
@@ -174,7 +174,7 @@ func loadKey(key string) (*pem.Block, error) {
 	)
 
 	if xpath.IsFile(key) {
-		buffer, err = ioutil.ReadFile(key)
+		buffer, err = os.ReadFile(key)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Starting with Go 1.16, should be call [os.ReadFile].