### PR TITLE
addad network workerpool

### DIFF
--- a/network/conn.go
+++ b/network/conn.go
@@ -45,5 +45,9 @@ type (
 		RemoteIP() (string, error)
 		// RemoteAddr 获取远端地址
 		RemoteAddr() (net.Addr, error)
+		// GetWorkerPool 获取工作池
+		GetWorkerPool() *WorkerPool
+		// GetWorkerID 获取工作ID
+		GetWorkerID() int32
 	}
 )

--- a/network/kcp/client_conn.go
+++ b/network/kcp/client_conn.go
@@ -27,6 +27,16 @@ type clientConn struct {
 	lastHeartbeatTime int64         // 上次心跳时间
 }
 
+// GetWorkerPool 获取工作池
+func (c *clientConn) GetWorkerPool() *network.WorkerPool {
+	return nil
+}
+
+// GetWorkerID 获取工作ID
+func (c *clientConn) GetWorkerID() int32 {
+	return 0
+}
+
 var _ network.Conn = &clientConn{}
 
 func newClientConn(client *client, id int64, conn net.Conn) network.Conn {

--- a/network/kcp/server.go
+++ b/network/kcp/server.go
@@ -19,6 +19,7 @@ type server struct {
 	opts              *serverOptions
 	listener          *kcp.Listener
 	connMgr           *serverConnMgr
+	wp                *network.WorkerPool       // 工作池
 	startHandler      network.StartHandler      // 服务器启动hook函数
 	stopHandler       network.CloseHandler      // 服务器关闭hook函数
 	connectHandler    network.ConnectHandler    // 连接打开hook函数
@@ -37,7 +38,7 @@ func NewServer(opts ...ServerOption) network.Server {
 	s := &server{}
 	s.opts = o
 	s.connMgr = newServerConnMgr(s)
-
+	s.wp = network.NewWorkerPool()
 	return s
 }
 
@@ -55,7 +56,7 @@ func (s *server) Start() error {
 	if s.startHandler != nil {
 		s.startHandler()
 	}
-
+	s.wp.StartWorkerPool(s.receiveHandler)
 	go s.serve()
 
 	return nil

--- a/network/task.go
+++ b/network/task.go
@@ -1,0 +1,51 @@
+package network
+
+import (
+	"sync"
+)
+
+type connTaskPool struct {
+	pool sync.Pool
+}
+
+var TaskPool = NewTaskPool()
+
+func NewTaskPool() *connTaskPool {
+	return &connTaskPool{pool: sync.Pool{New: func() interface{} { return ConnTask{} }}}
+}
+
+func (p *connTaskPool) Get(conn Conn, msg []byte) ConnTask {
+	t := p.pool.Get().(ConnTask)
+	t.Reset(conn, msg)
+	return t
+}
+
+func (p *connTaskPool) Put(t ConnTask) {
+	t.msg = nil
+	t.conn = nil
+	p.pool.Put(t)
+}
+
+type ConnTask struct {
+	conn Conn
+	msg  []byte
+}
+
+func (t *ConnTask) GetConn() Conn {
+	return t.conn
+}
+func (t *ConnTask) GetMsg() []byte {
+	return t.msg
+}
+func (t *ConnTask) Reset(conn Conn, msg []byte) {
+	t.msg = msg
+	t.conn = conn
+}
+
+// 避免如果在worker中新开一个协程去执行任务时,影响原始的执行过程
+func (t *ConnTask) Copy() *ConnTask {
+	return &ConnTask{
+		msg:  t.msg,
+		conn: t.conn,
+	}
+}

--- a/network/tcp/client_conn.go
+++ b/network/tcp/client_conn.go
@@ -27,6 +27,16 @@ type clientConn struct {
 	lastHeartbeatTime int64         // 上次心跳时间
 }
 
+// GetWorkerPool 获取工作池
+func (c *clientConn) GetWorkerPool() *network.WorkerPool {
+	return nil
+}
+
+// GetWorkerID 获取工作ID
+func (c *clientConn) GetWorkerID() int32 {
+	return 0
+}
+
 var _ network.Conn = &clientConn{}
 
 func newClientConn(client *client, id int64, conn net.Conn) network.Conn {

--- a/network/tcp/server.go
+++ b/network/tcp/server.go
@@ -11,6 +11,7 @@ type server struct {
 	opts              *serverOptions            // 配置
 	listener          net.Listener              // 监听器
 	connMgr           *serverConnMgr            // 连接管理器
+	wp                *network.WorkerPool       // 工作池
 	startHandler      network.StartHandler      // 服务器启动hook函数
 	stopHandler       network.CloseHandler      // 服务器关闭hook函数
 	connectHandler    network.ConnectHandler    // 连接打开hook函数
@@ -29,7 +30,7 @@ func NewServer(opts ...ServerOption) network.Server {
 	s := &server{}
 	s.opts = o
 	s.connMgr = newServerConnMgr(s)
-
+	s.wp = network.NewWorkerPool()
 	return s
 }
 
@@ -47,7 +48,7 @@ func (s *server) Start() error {
 	if s.startHandler != nil {
 		s.startHandler()
 	}
-
+	s.wp.StartWorkerPool(s.receiveHandler)
 	go s.serve()
 
 	return nil

--- a/network/worker.go
+++ b/network/worker.go
@@ -1,0 +1,128 @@
+package network
+
+import (
+	"sync"
+)
+
+type WorkerPool struct {
+	opts          *workerOptions
+	workers       map[int32]struct{}
+	workerMu      sync.Mutex
+	taskQueue     []chan ConnTask
+	extraWorkers  map[int32]struct{}
+	extraWorkerMu sync.Mutex
+}
+
+func (wp *WorkerPool) IsOpen() bool {
+	return wp.opts.workerNum > 0
+}
+
+func (wp *WorkerPool) isOpenExtra() bool {
+	return wp.IsOpen() && wp.opts.workerNum < wp.opts.maxWorkerNum
+}
+
+func (wp *WorkerPool) StartWorkerPool(fn ReceiveHandler) {
+	if !wp.IsOpen() {
+		return
+	}
+	for i := int32(0); i < wp.opts.workerNum; i++ {
+		wp.taskQueue[i] = make(chan ConnTask, wp.opts.taskNum)
+		go wp.doWork(wp.taskQueue[i], fn)
+	}
+}
+func (wp *WorkerPool) doWork(taskQueue chan ConnTask, fn ReceiveHandler) {
+	if fn == nil {
+		return
+	}
+	for {
+		select {
+		case ts, ok := <-taskQueue:
+			if !ok {
+				return
+			}
+			fn(ts.GetConn(), ts.GetMsg())
+		}
+	}
+}
+func (wp *WorkerPool) stopWork(workerID int32) {
+	// 关闭掉对应的任务队列即可
+	close(wp.taskQueue[workerID])
+}
+
+func RecycleWorker(conn Conn) {
+	workerID := conn.GetWorkerID()
+	wp := conn.GetWorkerPool()
+	if wp == nil || !wp.IsOpen() {
+		return
+	}
+	if workerID < wp.opts.workerNum {
+		wp.workerMu.Lock()
+		wp.workers[workerID] = struct{}{}
+		wp.workerMu.Unlock()
+	} else {
+		// 说明是扩展工作池归还时要停止这个worker
+		wp.workerMu.Lock()
+		wp.stopWork(workerID)
+		wp.extraWorkers[workerID] = struct{}{}
+		wp.workerMu.Unlock()
+	}
+
+}
+
+func BindWorker(conn Conn) (workerID int32) {
+	wp := conn.GetWorkerPool()
+	if !wp.IsOpen() {
+		return
+	}
+	wp.workerMu.Lock()
+	for workerId, _ := range wp.workers {
+		delete(wp.workers, workerId)
+		wp.workerMu.Unlock()
+		return workerId
+	}
+	wp.workerMu.Unlock()
+	if wp.isOpenExtra() {
+		wp.extraWorkerMu.Lock()
+		defer wp.extraWorkerMu.Unlock()
+		for workerId, _ := range wp.extraWorkers {
+			delete(wp.extraWorkers, workerId)
+			return workerId
+		}
+	}
+	if wp.opts.workerNum == 0 {
+		workerID = 0
+	} else {
+		workerID = int32(conn.ID() % int64(wp.opts.workerNum))
+	}
+	return
+}
+
+func (wp *WorkerPool) AddTask(task ConnTask) {
+	wp.taskQueue[task.GetConn().GetWorkerID()] <- task
+}
+func NewWorkerPool(opts ...WorkerOption) *WorkerPool {
+	o := defaultWorkerOptions()
+	for _, opt := range opts {
+		opt(o)
+	}
+	wp := &WorkerPool{}
+	wp.opts = o
+	wp.workers = make(map[int32]struct{})
+	wp.workerMu.Lock()
+	for i := int32(0); i < wp.opts.workerNum; i++ {
+		wp.workers[i] = struct{}{}
+	}
+	taskQueueSize := wp.opts.workerNum
+	wp.workerMu.Unlock()
+	if wp.isOpenExtra() {
+		wp.extraWorkers = make(map[int32]struct{})
+		wp.extraWorkerMu.Lock()
+		for i := wp.opts.workerNum; i < wp.opts.maxWorkerNum; i++ {
+			wp.extraWorkers[i] = struct{}{}
+		}
+		wp.extraWorkerMu.Unlock()
+		taskQueueSize = wp.opts.maxWorkerNum
+	}
+	wp.taskQueue = make([]chan ConnTask, taskQueueSize)
+	return wp
+}

--- a/network/worker_options.go
+++ b/network/worker_options.go
@@ -1,0 +1,45 @@
+package network
+
+import "github.com/dobyte/due/v2/etc"
+
+const (
+	defaultWorkerNum    = 0
+	defaultMaxWorkerNum = 5000
+	defaultTaskNum      = 50
+)
+const (
+	defaultWorkerNumKey    = "etc.network.worker.workerNum"
+	defaultMaxWorkerNumKey = "etc.network.worker.maxWorkerNum"
+	defaultTaskNumKey      = "etc.network.worker.taskNum"
+)
+
+type WorkerOption func(o *workerOptions)
+
+type workerOptions struct {
+	workerNum    int32 // 工作池个数,0的话为不开启工作池
+	maxWorkerNum int32 // 最大工作池个数
+	taskNum      int32 // 每个任务队列任务个数,默认50
+}
+
+func defaultWorkerOptions() *workerOptions {
+	return &workerOptions{
+		workerNum:    etc.Get(defaultWorkerNumKey, defaultWorkerNum).Int32(),
+		maxWorkerNum: etc.Get(defaultMaxWorkerNumKey, defaultMaxWorkerNum).Int32(),
+		taskNum:      etc.Get(defaultTaskNumKey, defaultTaskNum).Int32(),
+	}
+}
+
+// WithWorkerNum 设置工作池个数
+func WithWorkerNum(workerNum int32) WorkerOption {
+	return func(o *workerOptions) { o.workerNum = workerNum }
+}
+
+// WithMaxWorkerNum 设置最大工作池个数
+func WithMaxWorkerNum(maxWorkerNum int32) WorkerOption {
+	return func(o *workerOptions) { o.maxWorkerNum = maxWorkerNum }
+}
+
+// WithTaskNum 设置任务队列任务个数
+func WithTaskNum(taskNum int32) WorkerOption {
+	return func(o *workerOptions) { o.taskNum = taskNum }
+}

--- a/network/ws/client_conn.go
+++ b/network/ws/client_conn.go
@@ -29,6 +29,16 @@ type clientConn struct {
 	close             chan struct{}   // 关闭信号
 }
 
+// GetWorkerPool 获取工作池
+func (c *clientConn) GetWorkerPool() *network.WorkerPool {
+	return nil
+}
+
+// GetWorkerID 获取工作ID
+func (c *clientConn) GetWorkerID() int32 {
+	return 0
+}
+
 var _ network.Conn = &clientConn{}
 
 func newClientConn(id int64, conn *websocket.Conn, client *client) network.Conn {

--- a/network/ws/server.go
+++ b/network/ws/server.go
@@ -28,6 +28,7 @@ type server struct {
 	opts              *serverOptions            // 配置
 	listener          net.Listener              // 监听器
 	connMgr           *serverConnMgr            // 连接管理器
+	wp                *network.WorkerPool       // 工作池
 	startHandler      network.StartHandler      // 服务器启动hook函数
 	stopHandler       network.CloseHandler      // 服务器关闭hook函数
 	connectHandler    network.ConnectHandler    // 连接打开hook函数
@@ -47,7 +48,7 @@ func NewServer(opts ...ServerOption) Server {
 	s := &server{}
 	s.opts = o
 	s.connMgr = newConnMgr(s)
-
+	s.wp = network.NewWorkerPool()
 	return s
 }
 
@@ -70,7 +71,7 @@ func (s *server) Start() error {
 	if s.startHandler != nil {
 		s.startHandler()
 	}
-
+	s.wp.StartWorkerPool(s.receiveHandler)
 	xcall.Go(s.serve)
 
 	return nil

--- a/network/ws/server_conn.go
+++ b/network/ws/server_conn.go
@@ -23,17 +23,29 @@ import (
 )
 
 type serverConn struct {
-	rw                sync.RWMutex    // 锁
-	id                int64           // 连接ID
-	uid               int64           // 用户ID
-	state             int32           // 连接状态
-	conn              *websocket.Conn // WS源连接
-	connMgr           *serverConnMgr  // 连接管理
-	chLowWrite        chan chWrite    // 低级队列
-	chHighWrite       chan chWrite    // 优先队列
-	done              chan struct{}   // 写入完成信号
-	close             chan struct{}   // 关闭信号
-	lastHeartbeatTime int64           // 上次心跳时间
+	rw                sync.RWMutex        // 锁
+	id                int64               // 连接ID
+	uid               int64               // 用户ID
+	state             int32               // 连接状态
+	conn              *websocket.Conn     // WS源连接
+	connMgr           *serverConnMgr      // 连接管理
+	wp                *network.WorkerPool // 工作池
+	workerID          int32               // 工作ID
+	chLowWrite        chan chWrite        // 低级队列
+	chHighWrite       chan chWrite        // 优先队列
+	done              chan struct{}       // 写入完成信号
+	close             chan struct{}       // 关闭信号
+	lastHeartbeatTime int64               // 上次心跳时间
+}
+
+// GetWorkerPool 获取工作池
+func (c *serverConn) GetWorkerPool() *network.WorkerPool {
+	return c.wp
+}
+
+// GetWorkerID 获取工作ID
+func (c *serverConn) GetWorkerID() int32 {
+	return c.workerID
 }
 
 var _ network.Conn = &serverConn{}
@@ -159,6 +171,8 @@ func (c *serverConn) init(cm *serverConnMgr, id int64, conn *websocket.Conn) {
 	c.id = id
 	c.conn = conn
 	c.connMgr = cm
+	c.wp = cm.server.wp
+	c.workerID = network.BindWorker(c)
 	c.chLowWrite = make(chan chWrite, 4096)
 	c.chHighWrite = make(chan chWrite, 1024)
 	c.done = make(chan struct{})
@@ -210,6 +224,7 @@ func (c *serverConn) graceClose(isNeedRecycle bool) error {
 	close(c.close)
 	close(c.done)
 	conn := c.conn
+	network.RecycleWorker(c)
 	c.conn = nil
 	c.rw.Unlock()
 
@@ -240,6 +255,7 @@ func (c *serverConn) forceClose(isNeedRecycle bool) error {
 	close(c.close)
 	close(c.done)
 	conn := c.conn
+	network.RecycleWorker(c)
 	c.conn = nil
 	c.rw.Unlock()
 
@@ -315,9 +331,12 @@ func (c *serverConn) read() {
 				}
 				continue
 			}
-
-			if c.connMgr.server.receiveHandler != nil {
-				c.connMgr.server.receiveHandler(c, msg)
+			if c.wp.IsOpen() {
+				c.wp.AddTask(network.TaskPool.Get(c, msg))
+			} else {
+				if c.connMgr.server.receiveHandler != nil {
+					c.connMgr.server.receiveHandler(c, msg)
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Added worker poll mechanism to the network server to quickly process client requests
You can configure the parameters of workerpool by yourself
//WorkerNum is the number of work pools. If it is 0, the work pool will not be enabled
//MaxWorkerNum is the maximum number of work pools, provided that WorkerNum is not equal to 0
/TaskNum is the number of tasks in each task queue, with a default of 50. Each worker can handle a maximum of 50 tasks