### PR TITLE
fix(config): Redundant Checks

### DIFF
--- a/config/configurator.go
+++ b/config/configurator.go
@@ -301,7 +301,7 @@ func (c *defaultConfigurator) doGet(pattern string) (value.Value, bool) {
 		values = c.load()
 	)
 
-	if values == nil || len(values) == 0 {
+	if len(values) == 0 {
 		goto NOTFOUND
 	}
 


### PR DESCRIPTION
删除 values == nil || 部分，因为 len(values) 对于 nil map 会返回 0，所以单独检查长度就足够了