### PR TITLE
fix: change fixed UnaryInterceptor to ChainUnaryInterceptor

### DIFF
--- a/transport/grpc/internal/server/server.go
+++ b/transport/grpc/internal/server/server.go
@@ -36,7 +36,7 @@ func NewServer(opts *Options) (*Server, error) {
 	isSecure := false
 	serverOpts := make([]grpc.ServerOption, 0, len(opts.ServerOpts)+2)
 	serverOpts = append(serverOpts, opts.ServerOpts...)
-	serverOpts = append(serverOpts, grpc.UnaryInterceptor(recoverInterceptor))
+	serverOpts = append(serverOpts, grpc.ChainUnaryInterceptor(recoverInterceptor))
 	if opts.CertFile != "" && opts.KeyFile != "" {
 		cred, err := credentials.NewServerTLSFromFile(opts.CertFile, opts.KeyFile)
 		if err != nil {


### PR DESCRIPTION
初始化grpc服务端时，默认UnaryInterceptor一个recoverInterceptor，当在外部添加其他拦截器时，导致 “The unary server interceptor was already set and may not be reset” ，改成 ChainUnaryInterceptor 一个 recoverInterceptor。允许在外部添加其他的拦截器