### PR TITLE
fix grpc and rpcx transporters builder no discovery client error

### DIFF
--- a/transport/grpc/transporter.go
+++ b/transport/grpc/transporter.go
@@ -1,11 +1,13 @@
 package grpc
 
 import (
+	"sync"
+
 	"github.com/dobyte/due/transport/grpc/v2/internal/client"
 	"github.com/dobyte/due/transport/grpc/v2/internal/server"
+	"github.com/dobyte/due/v2/errors"
 	"github.com/dobyte/due/v2/registry"
 	"github.com/dobyte/due/v2/transport"
-	"sync"
 )
 
 const name = "grpc"
@@ -48,9 +50,19 @@ func (t *Transporter) NewServer() (transport.Server, error) {
 // 服务直连模式: 	direct://711baf8d-8a06-11ef-b7df-f4f19e1f0070
 // 服务发现模式: 	discovery://service_name
 func (t *Transporter) NewClient(target string) (transport.Client, error) {
+	var err error
+
 	t.once.Do(func() {
-		t.builder = client.NewBuilder(&t.opts.client)
+		if t.opts.client.Discovery == nil {
+			err = errors.New("grpc discovery client is not ready")
+		} else {
+			t.builder = client.NewBuilder(&t.opts.client)
+		}
 	})
+
+	if err != nil {
+		return nil, err
+	}
 
 	cc, err := t.builder.Build(target)
 	if err != nil {

--- a/transport/rpcx/transporter.go
+++ b/transport/rpcx/transporter.go
@@ -1,12 +1,14 @@
 package rpcx
 
 import (
+	"sync"
+
 	"github.com/dobyte/due/transport/rpcx/v2/internal/client"
 	"github.com/dobyte/due/transport/rpcx/v2/internal/logger"
 	"github.com/dobyte/due/transport/rpcx/v2/internal/server"
+	"github.com/dobyte/due/v2/errors"
 	"github.com/dobyte/due/v2/registry"
 	"github.com/dobyte/due/v2/transport"
-	"sync"
 )
 
 const name = "rpcx"
@@ -51,9 +53,19 @@ func (t *Transporter) NewServer() (transport.Server, error) {
 // 服务直连模式: 	direct://711baf8d-8a06-11ef-b7df-f4f19e1f0070
 // 服务发现模式: 	discovery://service_name
 func (t *Transporter) NewClient(target string) (transport.Client, error) {
+	var err error
+
 	t.once.Do(func() {
-		t.builder = client.NewBuilder(&t.opts.client)
+		if t.opts.client.Discovery == nil {
+			err = errors.New("rpcx discovery client is not ready")
+		} else {
+			t.builder = client.NewBuilder(&t.opts.client)
+		}
 	})
+
+	if err != nil {
+		return nil, err
+	}
 
 	cli, err := t.builder.Build(target)
 	if err != nil {


### PR DESCRIPTION
使用不当时，在服务没有初始化完成前创建了rpc客户端会导致服务发现不再可用，Transporter.builder中没有注册服务发现解析器。本次修改只是防止创建没有服务发现解析器的builder